### PR TITLE
Update Transform docstring

### DIFF
--- a/tomosipo/geometry/transform.py
+++ b/tomosipo/geometry/transform.py
@@ -7,7 +7,20 @@ from tomosipo.types import ToHomogeneousVec, ToScalars
 
 
 class Transform(object):
-    """Documentation for Transform"""
+    """Homogeneous coordinate transform
+
+    A :class:`Transform` stores one or more ``4\u00d74`` transformation
+    matrices.  Instances can be multiplied to compose translations,
+    rotations or other linear operations. The resulting transform can be
+    applied to vectors via :py:meth:`transform_vec` or to points via
+    :py:meth:`transform_point`.
+
+    Basic usage
+    -----------
+    >>> T = ts.translate((1, 0, 0))
+    >>> T.transform_point((0, 0, 0))
+    array([1., 0., 0.])
+    """
 
     def __init__(self, matrix):
         super(Transform, self).__init__()


### PR DESCRIPTION
## Summary
- replace placeholder docstring for `Transform` class with a short description and usage example

## Testing
- `pytest -k test_transform -q` *(fails: ImportError: libcudart.so.12)*